### PR TITLE
Add ggsurveillance to data visualisation

### DIFF
--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -104,9 +104,9 @@ and exploration of epidemiological data.
   estimation of daily growth
   rate. [RECON](https://www.repidemicsconsortium.org/) package. This package
   is scheduled for deprecation and is replaced by `r pkg("incidence2")`.
-- `r pkg("ggsurveillance")`: Provides `ggplot2` geoms for case visualization like epicurves or epigantt charts. 
-  Includes `tidyverse` compatible functions and `ggplot2` stats for date transformations 
-  (e.g. binning by week or month or seasonal alignment of case data). Further includes `ggplot2` scales for 
+- `r pkg("ggsurveillance")`: Provides `ggplot2` geoms for case visualization like epicurves or epigantt charts.
+  Includes `tidyverse` compatible functions and `ggplot2` stats for date transformations
+  (e.g. binning by week or month or seasonal alignment of case data). Further includes `ggplot2` scales for
   case data visualization and other helper functions (e.g. for creating age groups).
 
 ## Infectious disease modeling


### PR DESCRIPTION
Hi,

I would kindly ask for the inclusion of `ggsurveillance` into the CRAN Task View Epidemiology.

All changes were checked using `ctv`. 

I am happy to provide more information if needed.

Greetings
Alex

URLs:
https://cran.r-project.org/web/packages/ggsurveillance/index.html
https://github.com/biostats-dev/ggsurveillance
https://ggsurveillance.biostats.dev/
