### PR TITLE
Add simulist to Epidemic simulation models

### DIFF
--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -415,6 +415,11 @@ task view, which has a dedicated section on
 - `r pkg("genSEIR")`: Generalized Susceptible-Exposed-Infected-Recovered (SEIR)
   modeling, as described in
   [Peng et al. (2020)](https://doi.org/10.1101/2020.02.16.20023465).
+- `r pkg("simulist")`: Simulate realistic line list and contact tracing data
+  using a branching process model, age-structured populations,
+  age-stratified hospitalisation and death risk and time-varying case
+  fatality risk, as well as real-time outbreak snapshots with
+  right-truncation and creating "messy" line list data.
 
 ### Transmission tree reconstruction and genomic epidemiology
 


### PR DESCRIPTION
This PR adds the {simulist} R package to the Epidemic simulation models section of the Epidemiology CRAN task view. 

Changes checked locally with {ctv}.

URL: https://cran.r-project.org/package=simulist
GitHub: https://github.com/epiverse-trace/simulist
Pkgdown: https://epiverse-trace.github.io/simulist/