### PR TITLE
Remove epitweetr package from task view

### DIFF
--- a/Epidemiology.md
+++ b/Epidemiology.md
@@ -258,14 +258,6 @@ task view, which has a dedicated section on
   [Yang, S., Santillana, M. and Kou, S.C.
   (2015)](https://doi.org/10.1073/pnas.1515373112) and [Ning, S., Yang, S. and
   Kou, S.C. (2019)](https://doi.org/10.1038/s41598-019-41559-6).
-- `r pkg("epitweetr")`: Early Detection of Public Health Threats from 'Twitter'
-  Data. This package allows you to automatically monitor trends of tweets by
-  time, place and topic aiming at detecting public health threats early through
-  the detection of signals (e.g. an unusual increase in the number of tweets).
-  It was designed to focus on infectious diseases, and it can be extended to all
-  hazards or other fields of study by modifying the topics and keywords. More
-  information is available in the ['epitweetr' peer-review
-  publication](https://doi.org/10.2807/1560-7917.ES.2022.27.39.2200177).
 
 ### Estimation of transmissibility and forecasting
 

--- a/data/removed.csv
+++ b/data/removed.csv
@@ -1,2 +1,3 @@
 package,removed_on,reason,
 i2extras,2024-06-04,"maintainer request",
+epitweetr,2025-06-19,"archived on CRAN",

--- a/data/source_repositories.csv
+++ b/data/source_repositories.csv
@@ -85,7 +85,6 @@
 "epitab","stulacy/epitab"
 "epitools",NA
 "epitrix","reconhub/epitrix"
-"epitweetr","EU-ECDC/epitweetr"
 "epiworldR","UofUEpiBio/epiworldR"
 "epiworldRShiny","UofUEpiBio/epiworldRShiny"
 "etm","mclements/etm"


### PR DESCRIPTION
Given the state of the twitter API, it is unlikely to ever come back in a useful form.

Fix #50 